### PR TITLE
Add toggle between raw and calibrated magn values

### DIFF
--- a/qml/pages/MagnetPage.qml
+++ b/qml/pages/MagnetPage.qml
@@ -16,11 +16,32 @@ Page {
             text: i18n.tr('Back')
             onTriggered: page.StackView.view.pop();
         }
+        trailingActionBar.actions: [
+            UITK.Action {
+                onTriggered: !menu.visible ? menu.open() : menu.close()
+                iconName: "contextual-menu"
+            }
+        ]
     }
 
     Menu {
         id: menu
         x: parent.width - width
+        MenuItem {
+            function toggleReturnGeoValues() {
+                returnGeoValues = !returnGeoValues;
+                
+                magnetometer.setReturnGeoValues(returnGeoValues);
+                magnetometer.restart();
+
+                xplot.reset();
+                yplot.reset();
+                zplot.reset();
+            }
+
+            text: i18n.tr("Show ") + (returnGeoValues ? i18n.tr("raw") : i18n.tr("calibrated")) + i18n.tr(" readings")
+            onClicked: toggleReturnGeoValues()
+        }        
         MenuItem {
             function toggleLogging() {
                 if(magnetometer.isLogging) {
@@ -33,7 +54,9 @@ Page {
             text: (magnetometer.isLogging ? i18n.tr("Stop") : i18n.tr("Start")) + i18n.tr(" logging")
             onClicked: toggleLogging()
         }
-        }
+    }
+
+    property bool returnGeoValues: true;
 
     function formatNumber(n) {
         n *= 1e3;
@@ -62,7 +85,8 @@ Page {
         zplot.update();
     }
 
-    Component.onCompleted: {
+    Component.onCompleted: {   
+        magnetometer.setReturnGeoValues(returnGeoValues);     
         magnetometer.activate(Constants.PART_PAGE);
         magnetometer.mxChanged.connect(updateXPlot);
         magnetometer.myChanged.connect(updateYPlot);

--- a/src/magnetometer.cpp
+++ b/src/magnetometer.cpp
@@ -38,6 +38,21 @@ void Magnetometer::logValues(void)
     }
 }
 
+void Magnetometer::restart(void)
+{
+    QMagnetometer *magnetometer = dynamic_cast<QMagnetometer*>(m_sensor);
+    
+    magnetometer->stop();
+    magnetometer->start();
+}
+
+void Magnetometer::setReturnGeoValues(bool returnGeoValues)
+{
+    QMagnetometer *magnetometer = dynamic_cast<QMagnetometer*>(m_sensor);
+
+    magnetometer->setReturnGeoValues(returnGeoValues);    
+}
+
 void Magnetometer::refresh(void)
 {
     if(!m_sensor->isActive()) {

--- a/src/magnetometer.h
+++ b/src/magnetometer.h
@@ -32,6 +32,8 @@ class Magnetometer : public Sensor
     public slots:
         void refresh(void);
         void logValues(void);
+        void restart(void);
+        void setReturnGeoValues(bool returnGeoValues);
 
     signals:
         void mxChanged(void);


### PR DESCRIPTION
QMagnetometer provides both raw and calibrated magnetometer values. This PR adds a menu item in the magnetometer page to toggle between the two, with the calibrated reading being now the default. In order for the swap to take effect, the sensor needs to be restarted.